### PR TITLE
improve handling of AeSUSAR, AeInitial, action item

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 include = ambition_ae/*
-omit = ambition_ae/tests/*
+omit = ambition_ae/tests/*,ambition_ae/migrations/*
 branch = 1

--- a/ambition_ae/action_items.py
+++ b/ambition_ae/action_items.py
@@ -188,9 +188,6 @@ class AeSusarAction(ActionWithNotification):
     instructions = "Complete the AE SUSAR report"
     priority = HIGH_PRIORITY
 
-    def close_action_item_on_save(self):
-        return self.reference_obj.submitted_datetime
-
 
 class RecurrenceOfSymptomsAction(ActionWithNotification):
     name = RECURRENCE_OF_SYMPTOMS_ACTION

--- a/ambition_ae/action_items.py
+++ b/ambition_ae/action_items.py
@@ -1,5 +1,6 @@
 from ambition_prn.constants import DEATH_REPORT_ACTION
 from ambition_subject.constants import BLOOD_RESULTS_ACTION
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from edc_action_item import HIGH_PRIORITY, ActionWithNotification, site_action_items
 from edc_constants.constants import CLOSED, DEAD, LOST_TO_FOLLOWUP, YES, NO
@@ -9,7 +10,6 @@ from edc_visit_schedule.utils import get_offschedule_models
 from .constants import AE_FOLLOWUP_ACTION, AE_INITIAL_ACTION, AE_SUSAR_ACTION
 from .constants import AE_TMG_ACTION, RECURRENCE_OF_SYMPTOMS_ACTION
 from .constants import GRADE4, GRADE5
-from .email_contacts import email_contacts
 
 
 class AeTmgAction(ActionWithNotification):
@@ -44,8 +44,8 @@ class AeFollowupAction(ActionWithNotification):
     admin_site_name = "ambition_ae_admin"
     instructions = mark_safe(
         f"Upon submission the TMG group will be notified "
-        f'by email at <a href="mailto:{email_contacts.get("tmg")}">'
-        f'{email_contacts.get("tmg")}</a>'
+        f'by email at <a href="mailto:{settings.EMAIL_CONTACTS.get("tmg") or "#"}">'
+        f'{settings.EMAIL_CONTACTS.get("tmg") or "unknown"}</a>'
     )
     priority = HIGH_PRIORITY
 

--- a/ambition_ae/admin/ae_followup_admin.py
+++ b/ambition_ae/admin/ae_followup_admin.py
@@ -67,9 +67,7 @@ class AeFollowupAdmin(ModelAdminMixin, NonAeInitialModelAdminMixin, admin.ModelA
         link = None
         if obj.followup == YES:
             try:
-                ae_followup = self.model.objects.get(
-                    parent_action_item=obj.action_item
-                )
+                ae_followup = self.model.objects.get(parent_action_item=obj.action_item)
             except ObjectDoesNotExist:
                 ae_followup = None
             link = self.ae_followup(ae_followup)

--- a/ambition_ae/admin/ae_followup_admin.py
+++ b/ambition_ae/admin/ae_followup_admin.py
@@ -67,25 +67,25 @@ class AeFollowupAdmin(ModelAdminMixin, NonAeInitialModelAdminMixin, admin.ModelA
         link = None
         if obj.followup == YES:
             try:
-                ae_follow_up = self.model.objects.get(
+                ae_followup = self.model.objects.get(
                     parent_action_item=obj.action_item
                 )
             except ObjectDoesNotExist:
-                ae_follow_up = None
-            link = self.ae_follow_up(ae_follow_up)
+                ae_followup = None
+            link = self.ae_followup(ae_followup)
         elif obj.followup == NO and obj.ae_grade != NOT_APPLICABLE:
             link = self.initial_ae(obj)
         if link:
             return mark_safe(f"{obj.get_outcome_display()}. See {link}.")
         return obj.get_outcome_display()
 
-    def ae_follow_up(self, obj):
+    def ae_followup(self, obj):
         if obj:
             url_name = "_".join(obj._meta.label_lower.split("."))
             namespace = ambition_ae_admin.name
             url = reverse(f"{namespace}:{url_name}_changelist")
             return mark_safe(
-                f'<a title="go to next AE follow up report" '
+                f'<a title="go to next {obj._meta.verbose_name} report" '
                 f'href="{url}?q={obj.action_identifier}">'
                 f"{obj.identifier}</a>"
             )

--- a/ambition_ae/admin/ae_initial_admin.py
+++ b/ambition_ae/admin/ae_initial_admin.py
@@ -8,12 +8,11 @@ from django.urls.base import reverse
 from django.utils.safestring import mark_safe
 from edc_action_item import action_fieldset_tuple, action_fields
 from edc_base.utils import convert_php_dateformat
-from edc_constants.constants import OTHER, YES, NO, DEAD
+from edc_constants.constants import OTHER, YES, DEAD
 from edc_model_admin import audit_fieldset_tuple
 from simple_history.admin import SimpleHistoryAdmin
 
 from ..admin_site import ambition_ae_admin
-from ..email_contacts import email_contacts
 from ..forms import AeInitialForm
 from ..models import AeInitial, AeFollowup
 from .modeladmin_mixins import ModelAdminMixin
@@ -23,7 +22,7 @@ from .modeladmin_mixins import ModelAdminMixin
 class AeInitialAdmin(ModelAdminMixin, SimpleHistoryAdmin):
 
     form = AeInitialForm
-    email_contact = email_contacts.get("ae_reports")
+    email_contact = settings.EMAIL_CONTACTS.get("ae_reports")
     additional_instructions = mark_safe(
         "Complete the initial AE report and forward to the TMG. "
         f'Email to <a href="mailto:{email_contact}">{email_contact}</a>'
@@ -110,7 +109,8 @@ class AeInitialAdmin(ModelAdminMixin, SimpleHistoryAdmin):
         "susar_reported",
     ]
 
-    search_fields = ["subject_identifier", "action_identifier", "tracking_identifier"]
+    search_fields = ["subject_identifier",
+                     "action_identifier", "tracking_identifier"]
 
     def get_readonly_fields(self, request, obj=None):
         fields = super().get_readonly_fields(request, obj=obj)
@@ -179,7 +179,9 @@ class AeInitialAdmin(ModelAdminMixin, SimpleHistoryAdmin):
             if obj.susar_reported == YES
             else '<font color="red">Not reported</font>'
         )
-        susar = "No" if obj.susar == NO else f"Yes. {susar_reported}"
+        susar = (
+            f"Yes. {susar_reported}" if obj.susar == YES else obj.get_susar_display()
+        )
         return mark_safe(
             ".<BR>".join(
                 [

--- a/ambition_ae/admin/ae_initial_admin.py
+++ b/ambition_ae/admin/ae_initial_admin.py
@@ -109,8 +109,7 @@ class AeInitialAdmin(ModelAdminMixin, SimpleHistoryAdmin):
         "susar_reported",
     ]
 
-    search_fields = ["subject_identifier",
-                     "action_identifier", "tracking_identifier"]
+    search_fields = ["subject_identifier", "action_identifier", "tracking_identifier"]
 
     def get_readonly_fields(self, request, obj=None):
         fields = super().get_readonly_fields(request, obj=obj)

--- a/ambition_ae/admin/ae_susar_admin.py
+++ b/ambition_ae/admin/ae_susar_admin.py
@@ -25,7 +25,7 @@ class AeSusarAdmin(ModelAdminMixin, NonAeInitialModelAdminMixin, admin.ModelAdmi
         "submitted_datetime",
     ]
 
-    list_filter = ("report_status", "report_datetime", "submitted_datetime")
+    list_filter = ("report_datetime", "submitted_datetime")
 
     search_fields = [
         "subject_identifier",
@@ -44,7 +44,6 @@ class AeSusarAdmin(ModelAdminMixin, NonAeInitialModelAdminMixin, admin.ModelAdmi
                     "ae_initial",
                     "report_datetime",
                     "submitted_datetime",
-                    "report_status",
                 )
             },
         ),

--- a/ambition_ae/email_contacts.py
+++ b/ambition_ae/email_contacts.py
@@ -1,6 +1,0 @@
-from django.conf import settings
-
-try:
-    email_contacts = settings.EMAIL_CONTACTS
-except AttributeError:
-    email_contacts = {"ae_report": "someone@example.com"}

--- a/ambition_ae/forms/ae_initial_form.py
+++ b/ambition_ae/forms/ae_initial_form.py
@@ -29,8 +29,7 @@ class AeInitialForm(
     def clean(self):
         cleaned_data = super().clean()
         if AeFollowup.objects.filter(ae_initial=self.instance.pk).exists():
-            url = reverse(
-                "ambition_ae_admin:ambition_ae_aefollowup_changelist")
+            url = reverse("ambition_ae_admin:ambition_ae_aefollowup_changelist")
             url = f"{url}?q={self.instance.action_identifier}"
             raise forms.ValidationError(
                 mark_safe(
@@ -49,8 +48,7 @@ class AeInitialForm(
             except ObjectDoesNotExist:
                 pass
             else:
-                url = reverse(
-                    "ambition_ae_admin:ambition_ae_aesusar_changelist")
+                url = reverse("ambition_ae_admin:ambition_ae_aesusar_changelist")
                 url = f"{url}?q={self.instance.action_identifier}"
                 dt = formatted_datetime(ae_susar.submitted_datetime)
                 raise forms.ValidationError(

--- a/ambition_ae/forms/ae_initial_form.py
+++ b/ambition_ae/forms/ae_initial_form.py
@@ -1,13 +1,17 @@
+from django.core.exceptions import ObjectDoesNotExist
+from edc_base.utils import formatted_datetime
 from ambition_ae.models.ae_followup import AeFollowup
 from django import forms
 from django.urls.base import reverse
 from django.utils.safestring import mark_safe
 from edc_action_item.forms import ActionItemFormMixin
+from edc_constants.constants import NO
 from edc_form_validators import FormValidatorMixin
 
 from ..form_validators import AeInitialFormValidator
-from ..models import AeInitial
+from ..models import AeInitial, AeSusar
 from .modelform_mixin import ModelFormMixin
+from django.db import transaction
 
 
 class AeInitialForm(
@@ -25,7 +29,8 @@ class AeInitialForm(
     def clean(self):
         cleaned_data = super().clean()
         if AeFollowup.objects.filter(ae_initial=self.instance.pk).exists():
-            url = reverse("ambition_ae_admin:ambition_ae_aefollowup_changelist")
+            url = reverse(
+                "ambition_ae_admin:ambition_ae_aefollowup_changelist")
             url = f"{url}?q={self.instance.action_identifier}"
             raise forms.ValidationError(
                 mark_safe(
@@ -34,6 +39,29 @@ class AeInitialForm(
                     f'See <A href="{url}">AE Follow-ups for {self.instance}</A>.'
                 )
             )
+
+        # don't allow user to change response to NO if
+        # SUSAR already submitted.
+        if self.cleaned_data.get("susar_reported") == NO:
+            try:
+                with transaction.atomic():
+                    ae_susar = AeSusar.objects.get(ae_initial=self.instance.pk)
+            except ObjectDoesNotExist:
+                pass
+            else:
+                url = reverse(
+                    "ambition_ae_admin:ambition_ae_aesusar_changelist")
+                url = f"{url}?q={self.instance.action_identifier}"
+                dt = formatted_datetime(ae_susar.submitted_datetime)
+                raise forms.ValidationError(
+                    {
+                        "susar_reported": mark_safe(
+                            f"SUSAR reported as submitted on {dt}. "
+                            f'See <A href="{url}">AE SUSAR for {self.instance}</A>.'
+                        )
+                    }
+                )
+
         return cleaned_data
 
     class Meta:

--- a/ambition_ae/models/ae_susar.py
+++ b/ambition_ae/models/ae_susar.py
@@ -9,10 +9,12 @@ from edc_base.model_mixins import BaseUuidModel, ReportStatusModelMixin
 from edc_base.model_validators.date import datetime_not_future
 from edc_base.sites import SiteModelMixin
 from edc_base.utils import get_utcnow
+from edc_constants.constants import CLOSED
 from edc_identifier.model_mixins import TrackingModelMixin
 
 from ..constants import AE_SUSAR_ACTION
 from .ae_initial import AeInitial
+from edc_base.choices import REPORT_STATUS
 
 
 class AeSusar(
@@ -40,6 +42,14 @@ class AeSusar(
         validators=[datetime_not_future],
         null=True,
         blank=True,
+    )
+
+    report_status = models.CharField(
+        verbose_name="What is the status of this report?",
+        max_length=25,
+        choices=REPORT_STATUS,
+        default=CLOSED,
+        editable=False,
     )
 
     on_site = ActionIdentifierSiteManager()

--- a/ambition_ae/signals.py
+++ b/ambition_ae/signals.py
@@ -30,11 +30,9 @@ def update_ae_notifications_for_tmg_group(
                 with transaction.atomic():
                     instance.groups.get(name=TMG)
             except ObjectDoesNotExist:
-                instance.userprofile.email_notifications.remove(
-                    tmg_ae_notification)
+                instance.userprofile.email_notifications.remove(tmg_ae_notification)
             else:
-                instance.userprofile.email_notifications.add(
-                    tmg_ae_notification)
+                instance.userprofile.email_notifications.add(tmg_ae_notification)
 
 
 @receiver(post_save, weak=False, dispatch_uid="update_ae_initial_for_susar")

--- a/ambition_ae/signals.py
+++ b/ambition_ae/signals.py
@@ -1,6 +1,6 @@
 from ambition_auth.group_names import TMG
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models.signals import m2m_changed, post_save
+from django.db.models.signals import m2m_changed, post_save, post_delete
 from django.dispatch.dispatcher import receiver
 from edc_base import get_utcnow
 from edc_constants.constants import YES, NO
@@ -8,6 +8,7 @@ from edc_notification.models import Notification
 
 from .constants import AE_TMG_ACTION
 from .models import AeSusar, AeInitial
+from django.db import transaction
 
 
 @receiver(m2m_changed, weak=False, dispatch_uid="update_ae_notifications_for_tmg_group")
@@ -26,11 +27,14 @@ def update_ae_notifications_for_tmg_group(
             pass
         else:
             try:
-                instance.groups.get(name=TMG)
+                with transaction.atomic():
+                    instance.groups.get(name=TMG)
             except ObjectDoesNotExist:
-                instance.userprofile.email_notifications.remove(tmg_ae_notification)
+                instance.userprofile.email_notifications.remove(
+                    tmg_ae_notification)
             else:
-                instance.userprofile.email_notifications.add(tmg_ae_notification)
+                instance.userprofile.email_notifications.add(
+                    tmg_ae_notification)
 
 
 @receiver(post_save, weak=False, dispatch_uid="update_ae_initial_for_susar")
@@ -38,25 +42,32 @@ def update_ae_initial_for_susar(sender, instance, raw, **kwargs):
 
     if not raw:
         if issubclass(sender, AeSusar):
-            if (
-                instance.submitted_datetime
-                and instance.ae_initial.susar_reported != YES
-            ):
-                instance.ae_initial.susar_reported = YES
-                instance.ae_initial.save(update_fields=["susar_reported"])
+            if instance.submitted_datetime:
+                if instance.ae_initial.susar_reported != YES:
+                    instance.ae_initial.susar_reported = YES
+                    instance.ae_initial.save(update_fields=["susar_reported"])
             elif instance.ae_initial.susar_reported != NO:
                 instance.ae_initial.susar_reported = NO
                 instance.ae_initial.save(update_fields=["susar_reported"])
 
 
 @receiver(post_save, weak=False, dispatch_uid="update_ae_initial_susar_reported")
-def update_ae_initial_susar_reported(sender, instance, raw, **kwargs):
-    if not raw:
+def update_ae_initial_susar_reported(sender, instance, raw, update_fields, **kwargs):
+    if not raw and not update_fields:
         if issubclass(sender, AeInitial):
             if instance.susar_reported == YES:
                 try:
-                    AeSusar.objects.get(ae_initial=instance)
+                    with transaction.atomic():
+                        AeSusar.objects.get(ae_initial=instance)
                 except ObjectDoesNotExist:
                     AeSusar.objects.create(
                         ae_initial=instance, submitted_datetime=get_utcnow()
                     )
+
+
+@receiver(post_delete, weak=False, dispatch_uid="post_delete_ae_susar")
+def post_delete_ae_susar(instance, **kwargs):
+    if isinstance(instance, AeSusar):
+        if instance.ae_initial.susar_reported != NO:
+            instance.ae_initial.susar_reported = NO
+            instance.ae_initial.save()

--- a/ambition_ae/tests/test_admin.py
+++ b/ambition_ae/tests/test_admin.py
@@ -20,8 +20,7 @@ class TestAdmin(AmbitionTestCaseMixin, TestCase):
 
     def setUp(self):
         self.subject_identifier = "12345"
-        RegisteredSubject.objects.create(
-            subject_identifier=self.subject_identifier)
+        RegisteredSubject.objects.create(subject_identifier=self.subject_identifier)
 
     def test_ae_followup_status(self):
         modeladmin = ambition_ae_admin._registry.get(AeFollowup)
@@ -58,11 +57,9 @@ class TestAdmin(AmbitionTestCaseMixin, TestCase):
             subject_identifier=self.subject_identifier,
         )
 
-        self.assertIn(
-            ae_followup.identifier, modeladmin.ae_followup(ae_followup)
-        )
+        self.assertIn(ae_followup.identifier, modeladmin.ae_followup(ae_followup))
 
-    @tag('4')
+    @tag("4")
     def test_ae_initial_follow_up_reports(self):
         modeladmin = ambition_ae_admin._registry.get(AeInitial)
         ae_initial = mommy.make_recipe(
@@ -84,14 +81,10 @@ class TestAdmin(AmbitionTestCaseMixin, TestCase):
             subject_identifier=self.subject_identifier,
         )
 
-        self.assertIn(
-            ae_followup1.identifier,
-            modeladmin.follow_up_reports(ae_initial))
-        self.assertIn(
-            ae_followup2.identifier,
-            modeladmin.follow_up_reports(ae_initial))
+        self.assertIn(ae_followup1.identifier, modeladmin.follow_up_reports(ae_initial))
+        self.assertIn(ae_followup2.identifier, modeladmin.follow_up_reports(ae_initial))
 
-    @tag('4')
+    @tag("4")
     def test_ae_initial_if_sae_reason(self):
         modeladmin = ambition_ae_admin._registry.get(AeInitial)
         ae_initial = mommy.make_recipe(
@@ -106,7 +99,7 @@ class TestAdmin(AmbitionTestCaseMixin, TestCase):
         )
         self.assertTrue(modeladmin.description(ae_initial))
 
-    @tag('4')
+    @tag("4")
     def test_ae_initial_description(self):
         modeladmin = ambition_ae_admin._registry.get(AeInitial)
         ae_initial = mommy.make_recipe(
@@ -114,7 +107,7 @@ class TestAdmin(AmbitionTestCaseMixin, TestCase):
         )
         self.assertTrue(modeladmin.description(ae_initial))
 
-    @tag('4')
+    @tag("4")
     def test_ae_initial_user(self):
         modeladmin = ambition_ae_admin._registry.get(AeInitial)
         ae_initial = mommy.make_recipe(

--- a/ambition_ae/tests/test_admin.py
+++ b/ambition_ae/tests/test_admin.py
@@ -1,0 +1,123 @@
+from ambition_ae.admin_site import ambition_ae_admin
+from ambition_ae.models import AeFollowup, AeInitial
+from ambition_rando.tests import AmbitionTestCaseMixin
+from django.test import TestCase, tag
+from edc_constants.constants import YES, NO, DEAD
+from edc_list_data.site_list_data import site_list_data
+from edc_registration.models import RegisteredSubject
+from model_mommy import mommy
+
+
+class TestAdmin(AmbitionTestCaseMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        site_list_data.autodiscover()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+    def setUp(self):
+        self.subject_identifier = "12345"
+        RegisteredSubject.objects.create(
+            subject_identifier=self.subject_identifier)
+
+    def test_ae_followup_status(self):
+        modeladmin = ambition_ae_admin._registry.get(AeFollowup)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+        ae_followup = mommy.make_recipe(
+            "ambition_ae.aefollowup",
+            ae_initial=ae_initial,
+            followup=YES,
+            subject_identifier=self.subject_identifier,
+        )
+        self.assertEqual(
+            modeladmin.status(ae_followup),
+            f"{ae_followup.get_outcome_display()}. See AE Followup.",
+        )
+
+        ae_followup.followup = NO
+        ae_followup.save()
+        self.assertEqual(
+            modeladmin.status(ae_followup), ae_followup.get_outcome_display()
+        )
+
+    def test_ae_followup_ae_follow_up(self):
+        modeladmin = ambition_ae_admin._registry.get(AeFollowup)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+
+        ae_followup = mommy.make_recipe(
+            "ambition_ae.aefollowup",
+            ae_initial=ae_initial,
+            followup=YES,
+            subject_identifier=self.subject_identifier,
+        )
+
+        self.assertIn(
+            ae_followup.identifier, modeladmin.ae_followup(ae_followup)
+        )
+
+    @tag('4')
+    def test_ae_initial_follow_up_reports(self):
+        modeladmin = ambition_ae_admin._registry.get(AeInitial)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+        self.assertIsNone(modeladmin.follow_up_reports(ae_initial))
+
+        ae_followup1 = mommy.make_recipe(
+            "ambition_ae.aefollowup",
+            ae_initial=ae_initial,
+            followup=YES,
+            subject_identifier=self.subject_identifier,
+        )
+
+        ae_followup2 = mommy.make_recipe(
+            "ambition_ae.aefollowup",
+            ae_initial=ae_initial,
+            followup=NO,
+            subject_identifier=self.subject_identifier,
+        )
+
+        self.assertIn(
+            ae_followup1.identifier,
+            modeladmin.follow_up_reports(ae_initial))
+        self.assertIn(
+            ae_followup2.identifier,
+            modeladmin.follow_up_reports(ae_initial))
+
+    @tag('4')
+    def test_ae_initial_if_sae_reason(self):
+        modeladmin = ambition_ae_admin._registry.get(AeInitial)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+        self.assertIsNone(modeladmin.follow_up_reports(ae_initial))
+
+        mommy.make_recipe(
+            "ambition_ae.aeinitial",
+            sae_reason=DEAD,
+            subject_identifier=self.subject_identifier,
+        )
+        self.assertTrue(modeladmin.description(ae_initial))
+
+    @tag('4')
+    def test_ae_initial_description(self):
+        modeladmin = ambition_ae_admin._registry.get(AeInitial)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+        self.assertTrue(modeladmin.description(ae_initial))
+
+    @tag('4')
+    def test_ae_initial_user(self):
+        modeladmin = ambition_ae_admin._registry.get(AeInitial)
+        ae_initial = mommy.make_recipe(
+            "ambition_ae.aeinitial", subject_identifier=self.subject_identifier
+        )
+        self.assertTrue(modeladmin.user(ae_initial))


### PR DESCRIPTION
If AeInitial is an SUSAR and SUSAR  report submitted (at the time of the AE Initial:
* create ae susar action
* create ae_susar model
* close action

If AeInitial  is an SUSAR and SUSAR  report submitted changes from YES to NO:
* block save since AeSUSAR model instance already exists

If AeInitial  is an SUSAR and SUSAR not report submitted:
* create ae susar action only